### PR TITLE
support for escaped symbols with double backticks

### DIFF
--- a/tests/test.yeti
+++ b/tests/test.yeti
@@ -136,6 +136,16 @@ done,
     b = {x = 12};
     a with b == b
 done,
+'escaped symbols' : do:
+    import yeti.lang.Struct;
+    
+    ``some @symb`` = 2; 
+    stru = {``one-var test`` = 'foo-text'};
+    
+    ``some @symb`` == 2 and
+    'foo-text' == stru.``one-var test``
+    and ((stru as ~Object) unsafely_as ~Struct)#get('one-var test')#equals("foo-text");
+done,
 ];
 
 var bad = 0;


### PR DESCRIPTION
Modified YetiParser to read any text between `` as a symbole name.

ie `some-sym @is` =2; creates a binding to 2 with the name 'some-sym @is'

This is tested for structs and normal bindings in tests.yeti 
