### PR TITLE
enable with sections ie (with {x = 1}) is sugar for do x: x with {x = 1}...

### DIFF
--- a/c/YetiParser.java
+++ b/c/YetiParser.java
@@ -918,8 +918,17 @@ interface YetiParser {
                     e.col = partial.col;
                     e = r;
                 } else {
-                    e = new XNode("rsection",
+                    if(s == "with"){
+                        partial.right = new Sym(partial.hashCode() + s);
+                        partial.right.pos(partial.line,partial.col);
+                        BinOp bp = new BinOp("with",FIRST_OP_LEVEL,true);
+                        bp.left = partial.right;
+                        bp.right = parseExpr.result();
+                        e= XNode.lambda(partial.right,bp,null);
+                    }else{
+                        e = new XNode("rsection",
                                 new Node[] { new Sym(s), parseExpr.result() });
+                    }
                 }
                 e.line = partial.line;
                 e.col = partial.col;

--- a/tests/test.yeti
+++ b/tests/test.yeti
@@ -205,6 +205,10 @@ done,
     b = {x = 12};
     a with b == b
 done,
+'with section': do:
+    default = {a = 10, b = true};
+    (with {a = 3}) default == {a = 3, b = true};
+done,
 'escaped symbols': do:
     import yeti.lang.Struct;
     


### PR DESCRIPTION
It would be good if 'with' could be used partially like an operator. So that 

(with {foo = 1}) 

is sugar for

do x: x with {foo = 1} done

The main reason to add this sugar ist to use with as an update operation for default values instead of the extend sematics of the 'normal' with.

If you have a structure with default values ie

default = {value1 = 1,value2 = true};

and want to update it to change value1 put make a typing mistake ie

default with { valu1 = 2}; //gives {value1 = 1, value2 = true, valu=2} instead of the intended {value1 = 2, value2 = true}

So that the compiler can check that it is better to:

do x: x with {valu1=2} done default //this would give a compile error

and even shorter and IMO  consisten with the "opertor-style" of with would be:

(with {valu1=2}) default

This patch seems to bring that - hopefully.

Thanks   
