### PR TITLE
syntactic sugar for bind functions - similar to do notation

### DIFF
--- a/tests/maybemonad.yeti
+++ b/tests/maybemonad.yeti
@@ -1,0 +1,13 @@
+module maybemonad;
+
+typedef maybe<a> = None () | Some a;
+
+bind fn x is ('a -> maybe<'b>) -> maybe<'a> -> maybe<'b> =
+	case x of
+	Some y: fn y;
+	None (): none;
+	esac;
+
+return x = Some x;
+
+{bind, return}

--- a/tests/test.yeti
+++ b/tests/test.yeti
@@ -1,5 +1,7 @@
 program test;
 
+maybemn = load maybemonad;
+
 expectCompileError testCode =
    (load yeti.lang.compiler.eval;
     case evaluateYetiCode [] [] testCode of
@@ -478,7 +480,24 @@ done,
 'Case.': do:
     f x is Case. 'b -> 'b = case x of Case a: a esac;
     f (Case 42) == 42
+done,
+'bind sugar' : do:
+    bind fn v = fn v;
+    x <- 1;
+    x = x + 1;
+    y <- 3 + 4;
+    z = x + y;
+    z == 9
+done,
+'bind sugar maybe' : do:
+    
+    r = (maybemn.r1 <- (Some (Some (Some 1)));
+    maybemn.r2 <- r1;
+    maybemn.r3 <- r2;
+    maybemn.return (r3 == 1));
+    r == (Some true);
 done
+
 ];
 
 var bad = 0;


### PR DESCRIPTION
Currently there are no new features added to yeti, however once this is over here is a proposal to add syntactic sugar for monad bind similar to Hasekll's do notation.

The attached code rewrites to bind operations node-sequences (Seq):

( f = doFoo();
g <- monadValue; //here starts the rewrite
x = return (g + 1);
mon.h <- x;
return h);

is rewritten to:

(f = doFoo();
bind do g: 
    x = return (g + 1);
    mon.bind do h:
            return h;
        done 
        x;
   done
   monadValue);

The 'bind' function has to be in scope. If the node left to the (<-) is a symbol a plain 'bind' is referenced, if the node left to (<-) is a FieldOp than the left part is evaluted to be a structure for the 'bind' function. This is useful to have different 'bind' functions (ie through named load). The 'field-name' becomes the argument name in the lambda.

The (<-) is only considered for rewrite if it is a direkt child of the squence and the left node ist either a symbol or a field-reference. The lambda always than extends to the end of the sequenze (the subsequence is recusively transformed). 
